### PR TITLE
feat: add Kimi ops token flow and Windows CI smoke

### DIFF
--- a/.github/workflows/windows-kimi-ops-smoke.yml
+++ b/.github/workflows/windows-kimi-ops-smoke.yml
@@ -1,0 +1,58 @@
+name: Windows Kimi Ops Smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  windows-kimi-ops-smoke:
+    name: Windows install and Kimi ops smoke
+    runs-on: windows-latest
+    env:
+      AUTOVMWARE_CI_MOCK: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: Run Python tests
+        shell: pwsh
+        run: python -m pytest -q
+
+      - name: Run installer in mock token mode
+        shell: pwsh
+        run: |
+          Remove-Item Env:\KIMI_API_KEY -ErrorAction SilentlyContinue
+          $target = Join-Path $env:RUNNER_TEMP "AutoVMware"
+          .\install.ps1 -RepoRoot $target -MockMode -SkipKimiInstall -DummyKimiToken "dummy-ci-token-not-real"
+          if (-not (Test-Path (Join-Path $target "config\kimi-ops.env.example"))) { throw "missing token env example" }
+          if (-not (Test-Path (Join-Path $target "config\kimi-token-status.json"))) { throw "missing token status" }
+          $status = Get-Content (Join-Path $target "config\kimi-token-status.json") -Raw | ConvertFrom-Json
+          if (-not $status.token_present) { throw "dummy token was not recognized" }
+          if ($status.token_value -ne "[redacted]") { throw "token value was not redacted" }
+          if ($status.real_vm_action_executed) { throw "installer reported a real VM action" }
+
+      - name: Query skill ops status with dummy token
+        shell: pwsh
+        run: |
+          $json = python .\skills\autovmware-macos-vmx-clone\scripts\cli.py ops-status --mock-token --format json
+          $json
+          $status = $json | ConvertFrom-Json
+          if (-not $status.skill_available) { throw "skill is not available" }
+          if (-not $status.token_present) { throw "dummy token was not recognized by skill" }
+          if ($status.token_value -ne "[redacted]") { throw "skill leaked token value" }
+          if ($status.vmware_touched) { throw "status query touched VMware" }
+          if ($status.real_vm_action_executed) { throw "status query executed a real VM action" }

--- a/README.md
+++ b/README.md
@@ -94,6 +94,29 @@ Set-ExecutionPolicy -Scope Process Bypass -Force
 .\install.ps1 -Force
 ```
 
+## Kimi token 申请和安全配置
+
+安装完成后，运维必须先向 Infra/Hermes 申请 Kimi ops token，不能把 token 写进仓库、Issue、PR、CI 日志或截图。完整 SOP 在 `docs\ops\kimi-token-sop.md`，配置模板在 `config\kimi-ops.example.json`，安装脚本也会在目标机生成 `config\kimi-ops.env.example` 和只含 `[redacted]` / `[missing]` 的 `config\kimi-token-status.json`。
+
+申请时提供机器标识、环境、用途、负责人、预计有效期、安装目录和是否真实 VMware 环境；不要附带任何现有 token。Infra/Hermes 通过批准的私密通道发放最小权限 token。运维在 Windows 目标机把 token 配到用户级环境变量，默认变量名为 `KIMI_API_KEY`：
+
+```powershell
+[Environment]::SetEnvironmentVariable("KIMI_API_KEY", "<issued-token>", "User")
+```
+
+验证 token 和技能是否可用，但不触碰 VMware：
+
+```powershell
+python .\skills\autovmware-macos-vmx-clone\scripts\cli.py ops-status --format json
+```
+
+CI 和本地 dry-run 只能使用 dummy token / mock mode：
+
+```powershell
+.\install.ps1 -RepoRoot "$env:TEMP\AutoVMware" -MockMode -SkipKimiInstall -DummyKimiToken "dummy-ci-token-not-real"
+python .\skills\autovmware-macos-vmx-clone\scripts\cli.py ops-status --mock-token --format json
+```
+
 ## 默认测试配置
 
 交付包内置当前测试环境参数：

--- a/config/kimi-ops.example.json
+++ b/config/kimi-ops.example.json
@@ -1,0 +1,12 @@
+{
+  "token_env_var": "KIMI_API_KEY",
+  "token_storage": "Windows machine/user environment variable or approved local secret store",
+  "token_value": "replace-with-issued-token-do-not-commit-real-value",
+  "token_mode": "env",
+  "mock_token_for_ci": "dummy-ci-token-not-real",
+  "notes": [
+    "Never commit a real token.",
+    "Never paste a real token into GitHub Issues, logs, CI output, or chat.",
+    "CI must use mock/dummy token mode only."
+  ]
+}

--- a/docs/ops/kimi-token-sop.md
+++ b/docs/ops/kimi-token-sop.md
@@ -1,0 +1,135 @@
+# Kimi 运维部署与 token 发放 SOP
+
+本文给运维和 Infra/Hermes 使用，目标是让 AutoVMware Kimi 运维服务可安装、可验证、可安全发放 token，同时避免真实凭证进入仓库、Issue 或 CI 日志。
+
+## 1. 适用范围
+
+- 适用：AutoVMware Windows 目标机上的 Kimi 运维服务安装、token 申请、配置、smoke 验证、轮换和撤销。
+- 不适用：在 CI 中执行真实 VMware 克隆、启动、停止、删除或读取真实 VMware 凭证。
+
+## 2. 谁可以申请 token
+
+申请人必须满足：
+
+- 是授权运维或 Infra 指定执行人。
+- 有明确机器、环境、用途和负责人。
+- 已安装或准备安装 AutoVMware Kimi 运维交付包。
+- 接受不得把 token 写入 GitHub、聊天记录、CI 日志或截图的安全要求。
+
+## 3. 申请信息字段
+
+向 Infra/Hermes 申请时，使用以下字段，不要附带任何已有 token：
+
+```text
+申请类型: AutoVMware Kimi ops token
+机器标识: <主机名/资产编号>
+环境: <prod/staging/test>
+用途: <例如 DEM-009 批量克隆运维>
+负责人: <姓名/飞书/微信>
+预计有效期: <例如 30 天>
+安装目录: <例如 C:\Users\PC12\Documents\AutoVMware>
+是否真实 VMware 环境: <是/否>
+备注: <授权范围、窗口期、回滚联系人>
+```
+
+## 4. Infra/Hermes 发放流程
+
+1. 核对申请人、机器、用途和有效期。
+2. 生成或分配最小权限 token。
+3. 记录 token 元数据：申请人、机器、用途、有效期、发放时间、撤销方式。
+4. 使用批准的私密通道传递 token；不要通过 GitHub Issue、PR、CI 变量输出、公开群或普通日志传递。
+5. 告知运维只把 token 配到本机环境变量或批准的本地 secret store。
+
+## 5. 运维配置流程
+
+在 Windows 目标机安装：
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass -Force
+.\install.ps1 -SkipKimiInstall
+```
+
+安装后查看示例：
+
+```powershell
+Get-Content C:\Users\PC12\Documents\AutoVMware\config\kimi-ops.env.example
+```
+
+配置真实 token 时，推荐使用用户级环境变量，变量名默认是 `KIMI_API_KEY`：
+
+```powershell
+[Environment]::SetEnvironmentVariable("KIMI_API_KEY", "<issued-token>", "User")
+```
+
+注意：上面的 `<issued-token>` 只能在本机私密操作中替换，不能出现在 GitHub、聊天、截图或 CI 日志里。
+
+## 6. 验证服务可用
+
+真实机器上先查 Kimi ops 状态，不执行 VMware 动作：
+
+```powershell
+python .\skills\autovmware-macos-vmx-clone\scripts\cli.py ops-status --format json
+```
+
+预期：
+
+- `skill_available` 为 `true`
+- `token_present` 为 `true`
+- `token_value` 只显示 `[redacted]`
+- `real_vm_action_executed` 为 `false`
+- `vmware_touched` 为 `false`
+
+然后运行 doctor：
+
+```powershell
+python .\skills\autovmware-macos-vmx-clone\scripts\cli.py doctor --format markdown
+```
+
+只有 doctor 通过并且运维明确确认计划后，才能进入真实克隆。
+
+## 7. CI / mock 模式
+
+GitHub Windows CI 只能使用 dummy token，不触碰真实 VMware：
+
+```powershell
+.\install.ps1 -RepoRoot "$env:RUNNER_TEMP\AutoVMware" -MockMode -SkipKimiInstall -DummyKimiToken "dummy-ci-token-not-real"
+python .\skills\autovmware-macos-vmx-clone\scripts\cli.py ops-status --mock-token --format json
+```
+
+CI 需要验证：
+
+- Windows runner checkout 成功。
+- Python / pytest 可用。
+- 安装脚本在 `-MockMode` 下完成目录和模板生成。
+- dummy token 只以 redacted 状态出现。
+- `ops-status` 可查询到技能可用。
+- 没有真实 VMware 动作。
+
+## 8. 轮换和撤销
+
+轮换：
+
+1. Infra/Hermes 生成新 token。
+2. 运维在本机替换 `KIMI_API_KEY`。
+3. 运行 `ops-status` 和 doctor。
+4. Infra/Hermes 撤销旧 token。
+5. 记录轮换时间、执行人和验证结果。
+
+撤销：
+
+1. Infra/Hermes 将 token 设为失效。
+2. 运维删除本机环境变量：
+
+```powershell
+[Environment]::SetEnvironmentVariable("KIMI_API_KEY", $null, "User")
+```
+
+3. 运行 `ops-status`，确认 `token_present=false` 或服务不可继续使用。
+4. 在交付记录里只写 token 元数据，不写 token 值。
+
+## 9. 禁止事项
+
+- 禁止把真实 token 写进仓库、Issue、PR、CI secret 输出、日志或截图。
+- 禁止 CI 连接真实 VMware 或执行真实 VM 操作。
+- 禁止脚本打印 token 明文；状态里只能显示 `[redacted]` / `[missing]`。
+- 禁止把 token 固化到 `install.ps1`、配置模板或技能脚本里。

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,9 @@
 param(
     [string]$RepoRoot = "C:\Users\PC12\Documents\AutoVMware",
     [string]$SkillSource = "",
+    [string]$KimiTokenEnvVar = "KIMI_API_KEY",
+    [string]$DummyKimiToken = "",
+    [switch]$MockMode,
     [switch]$SkipKimiInstall,
     [switch]$Force
 )
@@ -62,7 +65,8 @@ function Get-FreeGb {
 function Invoke-PreflightDoctor {
     param(
         [string]$SkillSourcePath,
-        [string]$TargetRepoRoot
+        [string]$TargetRepoRoot,
+        [bool]$UseMockMode
     )
 
     Write-Step "Running preflight checks"
@@ -105,7 +109,11 @@ function Invoke-PreflightDoctor {
         }
     }
 
-    if ($null -ne $config) {
+    if ($UseMockMode) {
+        Write-Check "Mock mode" $true "Skipping real VMX, target drive, and VMware CLI checks for CI or dry-run validation."
+    }
+
+    if ($null -ne $config -and -not $UseMockMode) {
         $sourceVmxOk = Test-Path -LiteralPath $config.source_vmx
         Write-Check "Source VMX" $sourceVmxOk $config.source_vmx
         if (-not $sourceVmxOk) { $failures.Add("The configured source VMX does not exist. Check the source image path.") }
@@ -130,21 +138,23 @@ function Invoke-PreflightDoctor {
         }
     }
 
-    $vmrun = Find-Executable "vmrun" @(
-        "C:\Program Files (x86)\VMware\VMware Workstation\vmrun.exe",
-        "C:\Program Files\VMware\VMware Workstation\vmrun.exe"
-    )
-    $vmrunOk = -not [string]::IsNullOrWhiteSpace($vmrun)
-    Write-Check "VMware vmrun" $vmrunOk $vmrun
-    if (-not $vmrunOk) { $failures.Add("VMware Workstation vmrun.exe was not found.") }
+    if (-not $UseMockMode) {
+        $vmrun = Find-Executable "vmrun" @(
+            "C:\Program Files (x86)\VMware\VMware Workstation\vmrun.exe",
+            "C:\Program Files\VMware\VMware Workstation\vmrun.exe"
+        )
+        $vmrunOk = -not [string]::IsNullOrWhiteSpace($vmrun)
+        Write-Check "VMware vmrun" $vmrunOk $vmrun
+        if (-not $vmrunOk) { $failures.Add("VMware Workstation vmrun.exe was not found.") }
 
-    $vdisk = Find-Executable "vmware-vdiskmanager" @(
-        "C:\Program Files (x86)\VMware\VMware Workstation\vmware-vdiskmanager.exe",
-        "C:\Program Files\VMware\VMware Workstation\vmware-vdiskmanager.exe"
-    )
-    $vdiskOk = -not [string]::IsNullOrWhiteSpace($vdisk)
-    Write-Check "VMware disk tool" $vdiskOk $vdisk
-    if (-not $vdiskOk) { $failures.Add("VMware Workstation vmware-vdiskmanager.exe was not found.") }
+        $vdisk = Find-Executable "vmware-vdiskmanager" @(
+            "C:\Program Files (x86)\VMware\VMware Workstation\vmware-vdiskmanager.exe",
+            "C:\Program Files\VMware\VMware Workstation\vmware-vdiskmanager.exe"
+        )
+        $vdiskOk = -not [string]::IsNullOrWhiteSpace($vdisk)
+        Write-Check "VMware disk tool" $vdiskOk $vdisk
+        if (-not $vdiskOk) { $failures.Add("VMware Workstation vmware-vdiskmanager.exe was not found.") }
+    }
 
     if ($failures.Count -gt 0 -and -not $Force) {
         Write-Host ""
@@ -166,10 +176,12 @@ if ([string]::IsNullOrWhiteSpace($SkillSource)) {
     $SkillSource = Join-Path $PSScriptRoot "skills\autovmware-macos-vmx-clone"
 }
 
-Invoke-PreflightDoctor -SkillSourcePath $SkillSource -TargetRepoRoot $RepoRoot
+Invoke-PreflightDoctor -SkillSourcePath $SkillSource -TargetRepoRoot $RepoRoot -UseMockMode ([bool]$MockMode)
 
 Write-Step "Checking Kimi CLI"
-if (-not $SkipKimiInstall) {
+if ($MockMode) {
+    Write-Host "Mock mode enabled; not installing or calling real Kimi CLI."
+} elseif (-not $SkipKimiInstall) {
     if (-not (Test-Command "kimi")) {
         Write-Host "kimi command was not found. Installing Kimi CLI through the official installer..."
         Invoke-RestMethod https://code.kimi.com/install.ps1 | Invoke-Expression
@@ -178,8 +190,10 @@ if (-not $SkipKimiInstall) {
     }
 }
 
-if (Test-Command "kimi") {
+if ((-not $MockMode) -and (Test-Command "kimi")) {
     kimi --version
+} elseif ($MockMode) {
+    Write-Host "Kimi CLI version check skipped in mock mode."
 } else {
     Write-Warning "Kimi CLI was not found. Re-run without -SkipKimiInstall or install Kimi CLI manually."
 }
@@ -199,6 +213,29 @@ if (-not (Test-Path -LiteralPath $defaultConfigTarget)) {
     Write-Host "Config already exists; leaving it unchanged: $defaultConfigTarget"
 }
 
+$tokenExamplePath = Join-Path $RepoRoot "config\kimi-ops.env.example"
+$tokenExample = @(
+    "# Copy to a local secret store or machine-level environment setup. Do not commit real values.",
+    ("{0}=replace-with-issued-token" -f $KimiTokenEnvVar),
+    "AUTOVMWARE_KIMI_TOKEN_MODE=env"
+)
+$tokenExample | Set-Content -LiteralPath $tokenExamplePath -Encoding ASCII
+Write-Host "Created token configuration example: $tokenExamplePath"
+
+$tokenStatusPath = Join-Path $RepoRoot "config\kimi-token-status.json"
+$tokenPresent = (-not [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($KimiTokenEnvVar))) -or (-not [string]::IsNullOrWhiteSpace($DummyKimiToken))
+$tokenStatus = [ordered]@{
+    ok = $true
+    token_env_var = $KimiTokenEnvVar
+    token_present = $tokenPresent
+    token_value = $(if ($tokenPresent) { "[redacted]" } else { "[missing]" })
+    token_mode = $(if ($MockMode) { "mock-dummy" } else { "env" })
+    mock_mode = [bool]$MockMode
+    real_vm_action_executed = $false
+}
+$tokenStatus | ConvertTo-Json | Set-Content -LiteralPath $tokenStatusPath -Encoding ASCII
+Write-Host "Created redacted token status: $tokenStatusPath"
+
 Write-Step "Next steps"
 Write-Host "1. Enter the AutoVMware directory and start Kimi:"
 Write-Host "   cd $RepoRoot"
@@ -210,4 +247,6 @@ Write-Host ""
 Write-Host "3. After doctor passes, ask Kimi to generate a default clone plan, up to 100 clones:"
 Write-Host "   Use the autovmware-macos-vmx-clone skill to clone 100 images with the default config. Check space with 100GB reserved, list the plan, then wait for my confirmation."
 Write-Host ""
-Write-Host "4. Kimi must list the source VMX, output directory, count, power-on policy, and every target path before any real clone."
+Write-Host "4. Before using Kimi, request a token from Infra/Hermes, set it in the machine environment variable shown in config\\kimi-ops.env.example, and never paste the real token into GitHub, logs, or chat."
+Write-Host ""
+Write-Host "5. Kimi must list the source VMX, output directory, count, power-on policy, and every target path before any real clone."

--- a/install.ps1
+++ b/install.ps1
@@ -72,9 +72,9 @@ function Invoke-PreflightDoctor {
     Write-Step "Running preflight checks"
     $failures = New-Object System.Collections.Generic.List[string]
 
-    $isWindows = $PSVersionTable.Platform -eq "Win32NT" -or $env:OS -eq "Windows_NT"
-    Write-Check "Windows" $isWindows "This installer must run on the Windows AutoVMware host."
-    if (-not $isWindows) { $failures.Add("Run this installer on the Windows target host.") }
+    $runningOnWindows = $PSVersionTable.Platform -eq "Win32NT" -or $env:OS -eq "Windows_NT"
+    Write-Check "Windows" $runningOnWindows "This installer must run on the Windows AutoVMware host."
+    if (-not $runningOnWindows) { $failures.Add("Run this installer on the Windows target host.") }
 
     $psOk = $PSVersionTable.PSVersion.Major -ge 5
     Write-Check "PowerShell version" $psOk $PSVersionTable.PSVersion.ToString()

--- a/scripts/bootstrap/windows-init-autovmware-kimi.ps1
+++ b/scripts/bootstrap/windows-init-autovmware-kimi.ps1
@@ -1,6 +1,9 @@
 param(
     [string]$RepoRoot = "C:\Users\PC12\Documents\AutoVMware",
     [string]$SkillSource = "",
+    [string]$KimiTokenEnvVar = "KIMI_API_KEY",
+    [string]$DummyKimiToken = "",
+    [switch]$MockMode,
     [switch]$SkipKimiInstall,
     [switch]$Force
 )
@@ -10,4 +13,4 @@ if (-not (Test-Path -LiteralPath $rootInstall)) {
     throw "在交付包根目录没有找到 install.ps1：$rootInstall"
 }
 
-& $rootInstall -RepoRoot $RepoRoot -SkillSource $SkillSource -SkipKimiInstall:$SkipKimiInstall -Force:$Force
+& $rootInstall -RepoRoot $RepoRoot -SkillSource $SkillSource -KimiTokenEnvVar $KimiTokenEnvVar -DummyKimiToken $DummyKimiToken -MockMode:$MockMode -SkipKimiInstall:$SkipKimiInstall -Force:$Force

--- a/skills/autovmware-macos-vmx-clone/SKILL.md
+++ b/skills/autovmware-macos-vmx-clone/SKILL.md
@@ -20,6 +20,7 @@ python scripts/cli.py discover --drive F --format markdown
 python scripts/cli.py validate-approval --approval-json approval.json
 python scripts/cli.py plan-clone --approval-json approval.json --format markdown
 python scripts/cli.py report-template --approval-json approval.json --output reports/dem009/clone-report.md
+python scripts/cli.py ops-status --mock-token --format json
 ```
 
 ### 默认测试配置
@@ -99,6 +100,14 @@ python scripts/cli.py report-template --approval-json approval.json --output rep
 ### 报告证据
 
 阶段报告要包含源 VMX、克隆数量、目标路径、创建前后剩余空间、每个克隆机的验证结果、是否开机、截图路径、是否触发禁止动作、清理结果和重跑结果。
+
+### Kimi ops token
+
+- 运维安装完成后，先按仓库 `docs/ops/kimi-token-sop.md` 向 Infra/Hermes 申请 token。
+- 真实 token 只能放在本机环境变量或批准的本地 secret store，默认变量名 `KIMI_API_KEY`。
+- 禁止在 GitHub Issue、PR、CI 输出、日志、截图或聊天里打印真实 token。
+- CI 只能使用 `ops-status --mock-token` 和 `install.ps1 -MockMode -DummyKimiToken ...`，不得连接真实 VMware。
+- `ops-status` 只返回 `[redacted]` / `[missing]`，用于证明技能可用、token 已配置或 dummy token 已注入，并且不执行真实虚拟机动作。
 
 ## setup
 

--- a/skills/autovmware-macos-vmx-clone/scripts/cli.py
+++ b/skills/autovmware-macos-vmx-clone/scripts/cli.py
@@ -209,7 +209,7 @@ def make_plan(approval_path: Path, *, free_gb: float | None = None) -> dict[str,
 
 def output_result(result: dict[str, Any], fmt: str) -> None:
     if fmt == "json":
-        print(json.dumps(result, ensure_ascii=False, indent=2))
+        print(json.dumps(result, ensure_ascii=True, indent=2))
         return
     print(markdown_result(result))
 

--- a/skills/autovmware-macos-vmx-clone/scripts/cli.py
+++ b/skills/autovmware-macos-vmx-clone/scripts/cli.py
@@ -8,7 +8,7 @@ import json
 import os
 import shutil
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -130,18 +130,27 @@ def doctor_result(config_path: Path | None = None) -> dict[str, Any]:
     target_root = Path(approval.target_root)
     root = Path(approval.target_root[:3])
     tools = find_vmware_tools()
+    source_exists = source.exists() if os.name == "nt" else None
+    target_exists = target_root.exists() if os.name == "nt" else None
+    target_free_gb = disk_free_gb(root)
     checks = {
         "Python 版本": sys.version.split()[0],
         "运行平台": sys.platform,
         "是否 Windows": os.name == "nt",
         "配置文件": str(config_path or DEFAULT_CONFIG),
         "是否已配置源 VMX": bool(approval.source_vmx),
-        "源 VMX 是否存在": source.exists() if os.name == "nt" else None,
-        "输出目录是否存在": target_root.exists() if os.name == "nt" else None,
-        "目标盘剩余空间 GB": disk_free_gb(root),
+        "源 VMX 是否存在": source_exists,
+        "输出目录是否存在": target_exists,
+        "目标盘剩余空间 GB": target_free_gb,
         "vmrun 路径": tools["vmrun"],
         "vmware-vdiskmanager 路径": tools["vmware-vdiskmanager"],
         "Kimi CLI 路径": shutil.which("kimi"),
+        "source_vmx_exists": source_exists,
+        "target_root_exists": target_exists,
+        "target_free_gb": target_free_gb,
+        "vmrun": tools["vmrun"],
+        "vmware_vdiskmanager": tools["vmware-vdiskmanager"],
+        "kimi_cli": shutil.which("kimi"),
         "警告": warnings,
     }
     blockers: list[str] = []
@@ -298,6 +307,29 @@ def command_doctor(args: argparse.Namespace) -> int:
     return 0 if result["ok"] else 2
 
 
+def command_ops_status(args: argparse.Namespace) -> int:
+    token_env_var = args.token_env_var
+    token_present = bool(os.environ.get(token_env_var)) or args.mock_token
+    result = {
+        "ok": True,
+        "action": "Kimi ops status check",
+        "real_vm_action_executed": False,
+        "checked_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "skill_available": Path(__file__).resolve().parent.parent.joinpath("SKILL.md").exists(),
+        "config_available": (Path(args.config) if args.config else DEFAULT_CONFIG).exists(),
+        "token_env_var": token_env_var,
+        "token_present": token_present,
+        "token_value": "[redacted]" if token_present else "[missing]",
+        "token_mode": "mock-dummy" if args.mock_token else "env",
+        "mock_mode": args.mock_token,
+        "vmware_touched": False,
+        "safe_for_ci": args.mock_token,
+        "forbidden_actions": "未触发",
+    }
+    output_result(result, args.format)
+    return 0 if result["ok"] else 2
+
+
 def command_report_template(args: argparse.Namespace) -> int:
     plan = make_plan(Path(args.approval_json))
     output_path = Path(args.output)
@@ -359,6 +391,13 @@ def build_parser() -> argparse.ArgumentParser:
     doctor.add_argument("--config")
     doctor.add_argument("--format", choices=("json", "markdown"), default="markdown")
     doctor.set_defaults(func=command_doctor)
+
+    status = subparsers.add_parser("ops-status")
+    status.add_argument("--config")
+    status.add_argument("--token-env-var", default="KIMI_API_KEY")
+    status.add_argument("--mock-token", action="store_true")
+    status.add_argument("--format", choices=("json", "markdown"), default="json")
+    status.set_defaults(func=command_ops_status)
 
     report = subparsers.add_parser("report-template")
     report.add_argument("--approval-json", required=True)

--- a/tests/test_autovmware_macos_clone_skill.py
+++ b/tests/test_autovmware_macos_clone_skill.py
@@ -111,3 +111,20 @@ def test_doctor_is_read_only_and_reports_non_windows_blocker(capsys) -> None:
     if sys.platform != "win32":
         assert exit_code == 2
         assert "不是 Windows" in payload["blockers"][0]
+
+
+def test_ops_status_redacts_dummy_token_and_is_vmware_safe(capsys) -> None:
+    cli = load_module("cli")
+
+    exit_code = cli.main(["ops-status", "--mock-token", "--format", "json"])
+    out = capsys.readouterr().out
+
+    payload = json.loads(out)
+    assert exit_code == 0
+    assert payload["skill_available"] is True
+    assert payload["token_present"] is True
+    assert payload["token_value"] == "[redacted]"
+    assert payload["token_mode"] == "mock-dummy"
+    assert payload["vmware_touched"] is False
+    assert payload["real_vm_action_executed"] is False
+    assert "dummy-ci-token-not-real" not in out

--- a/tests/test_release_scripts.py
+++ b/tests/test_release_scripts.py
@@ -19,3 +19,24 @@ def test_release_builder_encodes_powershell_scripts_with_utf8_bom() -> None:
 
     assert "UTF8Encoding($true)" in content
     assert 'Filter "*.ps1"' in content
+
+
+def test_install_script_supports_mock_token_mode_without_real_vmware() -> None:
+    content = (REPO_ROOT / "install.ps1").read_text(encoding="utf-8")
+
+    assert "[switch]$MockMode" in content
+    assert "[string]$DummyKimiToken" in content
+    assert "Skipping real VMX, target drive, and VMware CLI checks" in content
+    assert "[redacted]" in content
+
+
+def test_windows_ci_exercises_mock_install_and_ops_status() -> None:
+    content = (REPO_ROOT / ".github" / "workflows" / "windows-kimi-ops-smoke.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "runs-on: windows-latest" in content
+    assert "-MockMode" in content
+    assert "dummy-ci-token-not-real" in content
+    assert "ops-status --mock-token --format json" in content
+    assert "token_value -ne \"[redacted]\"" in content


### PR DESCRIPTION
## Summary

Closes #2.

This PR completes the AutoVMware Kimi ops deployment/token issuance MVP:

- Adds an ops-readable Kimi token request/issuance/configuration/rotation/revocation SOP.
- Adds a safe token configuration example with no real credential values.
- Extends `install.ps1` and the bootstrap wrapper with mock/dummy token mode for CI and dry-run validation.
- Adds `ops-status` to the AutoVMware skill CLI so CI/ops can verify skill availability and redacted token state without touching VMware.
- Adds Windows GitHub Actions smoke CI that checks out the repo, prepares Python/test deps, runs tests, executes the installer in mock mode, validates redacted dummy token handling, and queries the skill status.

## Safety

- No real tokens or VMware secrets are committed.
- CI uses only `dummy-ci-token-not-real` and `-MockMode`.
- CI does not call real VMware tools or execute real VM actions.
- `ops-status` reports token value only as `[redacted]` / `[missing]`.

## Validation

Local validation:

- `python3 -m pytest -q` -> 10 passed
- `python3 skills/autovmware-macos-vmx-clone/scripts/cli.py ops-status --mock-token --format json` -> PASS, token redacted, `real_vm_action_executed=false`, `vmware_touched=false`
- `git diff --check` -> PASS

CI validation expected on PR:

- Windows install and Kimi ops smoke / `windows-latest`
