### PR TITLE
fix: include Kimi ops config in release package

### DIFF
--- a/scripts/release/build-release.ps1
+++ b/scripts/release/build-release.ps1
@@ -31,6 +31,7 @@ $items = @(
     "install.ps1",
     "pyproject.toml",
     "uv.lock",
+    "config",
     "docs",
     "scripts",
     "skills",

--- a/tests/test_release_scripts.py
+++ b/tests/test_release_scripts.py
@@ -19,6 +19,11 @@ def test_release_builder_encodes_powershell_scripts_with_utf8_bom() -> None:
 
     assert "UTF8Encoding($true)" in content
     assert 'Filter "*.ps1"' in content
+    assert '"config"' in content
+
+
+def test_release_package_includes_kimi_ops_config_template() -> None:
+    assert (REPO_ROOT / "config" / "kimi-ops.example.json").exists()
 
 
 def test_install_script_supports_mock_token_mode_without_real_vmware() -> None:


### PR DESCRIPTION
## Summary

- Include `config/` in the release package builder so the Kimi ops token template ships with the AutoVMware release artifact.
- Add regression tests proving the release package config template is present.

## Validation

- `python3 -m pytest -q` -> 11 passed
- `git diff --check` -> pass
