### PR TITLE
feat: add Podman Hermes Brain deployment scaffold

### DIFF
--- a/.github/workflows/linux-brain-ci.yml
+++ b/.github/workflows/linux-brain-ci.yml
@@ -1,0 +1,66 @@
+name: Linux Brain CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  linux-brain-ci:
+    name: Linux tests and Podman brain artifact validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: Run Python tests
+        run: python -m pytest -q tests/test_hermes_brain_deployment.py tests/test_autovmware_macos_clone_skill.py tests/test_release_scripts.py
+
+      - name: Install Podman
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+          podman --version
+
+      - name: Validate Containerfile syntax and build context
+        run: |
+          test -f deploy/hermes-brain/Containerfile
+          test -f deploy/hermes-brain/start.sh
+          test -f deploy/hermes-brain/brain_api.py
+          test -f deploy/hermes-brain/env.example
+          podman build --help >/dev/null
+
+      - name: Static deploy script smoke
+        run: |
+          bash -n scripts/deploy/aliyun-podman-hermes-brain.sh
+          bash -n deploy/hermes-brain/start.sh
+
+      - name: Brain API local smoke
+        run: |
+          tmpdir=$(mktemp -d)
+          export BRAIN_API_HOST=127.0.0.1
+          export BRAIN_API_PORT=3104
+          export BRAIN_STATE_PATH="$tmpdir/workers.json"
+          python deploy/hermes-brain/brain_api.py >"$tmpdir/api.log" 2>"$tmpdir/api.err" &
+          pid=$!
+          trap 'kill $pid 2>/dev/null || true' EXIT
+          for i in $(seq 1 20); do
+            if curl -fsS http://127.0.0.1:3104/health; then break; fi
+            sleep 0.5
+          done
+          curl -fsS -X POST http://127.0.0.1:3104/workers/heartbeat \
+            -H 'Content-Type: application/json' \
+            -d '{"machine_id":"ci-machine","hostname":"ci","worker_version":"0.1.0","free_space_gb":123,"kimi_token_present":false,"current_state":"need_token","last_error":"ci"}'
+          curl -fsS http://127.0.0.1:3104/workers | grep ci-machine

--- a/deploy/hermes-brain/Containerfile
+++ b/deploy/hermes-brain/Containerfile
@@ -1,0 +1,37 @@
+# AutoVMware Hermes Brain container image.
+# This image intentionally keeps Feishu credentials outside the image; pass them via env file.
+# Runtime entrypoint starts `python -m hermes_cli.main gateway run --replace` via start.sh.
+FROM python:3.11-slim
+
+ARG HERMES_REPO=https://github.com/NousResearch/hermes-agent.git
+ARG HERMES_REF=main
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    HERMES_HOME=/opt/autovmware-hermes-brain/hermes \
+    HERMES_PROFILE=autovmware-brain \
+    BRAIN_API_HOST=0.0.0.0 \
+    BRAIN_API_PORT=3104 \
+    PATH=/opt/hermes-venv/bin:$PATH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git curl ca-certificates tini \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 --branch "${HERMES_REF}" "${HERMES_REPO}" /opt/hermes-agent \
+    && python -m venv /opt/hermes-venv \
+    && /opt/hermes-venv/bin/python -m pip install --upgrade pip setuptools wheel \
+    && /opt/hermes-venv/bin/python -m pip install -e /opt/hermes-agent
+
+WORKDIR /opt/autovmware-hermes-brain
+COPY deploy/hermes-brain/brain_api.py /opt/autovmware-hermes-brain/brain_api.py
+COPY deploy/hermes-brain/start.sh /opt/autovmware-hermes-brain/start.sh
+RUN chmod +x /opt/autovmware-hermes-brain/start.sh \
+    && mkdir -p /opt/autovmware-hermes-brain/hermes /opt/autovmware-hermes-brain/state /opt/autovmware-hermes-brain/logs
+
+EXPOSE 3104
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD curl -fsS "http://127.0.0.1:${BRAIN_API_PORT}/health" || exit 1
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/opt/autovmware-hermes-brain/start.sh"]

--- a/deploy/hermes-brain/brain_api.py
+++ b/deploy/hermes-brain/brain_api.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+STATE_PATH = Path(os.environ.get("BRAIN_STATE_PATH", "/opt/autovmware-hermes-brain/state/workers.json"))
+HOST = os.environ.get("BRAIN_API_HOST", "0.0.0.0")
+PORT = int(os.environ.get("BRAIN_API_PORT", "3104"))
+ALLOWED_STATES = {"ready", "blocked", "lost", "need_token", "low_disk", "doctor_failed", "installed", "token_ok", "doctor_ok", "plan_ready"}
+REQUIRED_HEARTBEAT_FIELDS = {
+    "machine_id",
+    "hostname",
+    "worker_version",
+    "free_space_gb",
+    "kimi_token_present",
+    "current_state",
+}
+
+
+def load_state() -> dict[str, Any]:
+    if not STATE_PATH.exists():
+        return {"workers": {}}
+    try:
+        return json.loads(STATE_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {"workers": {}}
+
+
+def save_state(payload: dict[str, Any]) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = STATE_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(STATE_PATH)
+
+
+def redact_worker(payload: dict[str, Any]) -> dict[str, Any]:
+    redacted = dict(payload)
+    for key in list(redacted):
+        lowered = key.lower()
+        if "token" in lowered and key != "kimi_token_present":
+            redacted[key] = "[redacted]"
+        if "password" in lowered or "secret" in lowered or "credential" in lowered:
+            redacted[key] = "[redacted]"
+    return redacted
+
+
+class BrainHandler(BaseHTTPRequestHandler):
+    server_version = "AutoVMwareHermesBrain/0.1"
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        # Default http.server logs request paths; keep logs minimal and avoid body/secret leakage.
+        print("%s - %s" % (self.address_string(), fmt % args), flush=True)
+
+    def send_json(self, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler name
+        if self.path == "/health":
+            state = load_state()
+            self.send_json(200, {"ok": True, "service": "autovmware-hermes-brain", "worker_count": len(state.get("workers", {}))})
+            return
+        if self.path == "/workers":
+            self.send_json(200, load_state())
+            return
+        self.send_json(404, {"ok": False, "error": "not_found"})
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler name
+        if self.path != "/workers/heartbeat":
+            self.send_json(404, {"ok": False, "error": "not_found"})
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        if length <= 0 or length > 65536:
+            self.send_json(400, {"ok": False, "error": "invalid_content_length"})
+            return
+
+        try:
+            payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            self.send_json(400, {"ok": False, "error": "invalid_json"})
+            return
+
+        missing = sorted(REQUIRED_HEARTBEAT_FIELDS - set(payload))
+        if missing:
+            self.send_json(422, {"ok": False, "error": "missing_fields", "fields": missing})
+            return
+        if payload.get("current_state") not in ALLOWED_STATES:
+            self.send_json(422, {"ok": False, "error": "invalid_state", "allowed_states": sorted(ALLOWED_STATES)})
+            return
+
+        worker = redact_worker(payload)
+        worker["last_heartbeat_at"] = int(time.time())
+        state = load_state()
+        state.setdefault("workers", {})[str(worker["machine_id"])] = worker
+        save_state(state)
+        self.send_json(202, {"ok": True, "machine_id": worker["machine_id"], "accepted_state": worker["current_state"]})
+
+
+if __name__ == "__main__":
+    server = ThreadingHTTPServer((HOST, PORT), BrainHandler)
+    print(f"brain_api listening on {HOST}:{PORT}; state={STATE_PATH}", flush=True)
+    server.serve_forever()

--- a/deploy/hermes-brain/env.example
+++ b/deploy/hermes-brain/env.example
@@ -1,0 +1,27 @@
+# AutoVMware Hermes Brain environment template
+# Copy to /opt/autovmware-hermes-brain/brain.env on Aliyun ECS and fill values there.
+# Never commit real secrets.
+
+# Feishu/Lark bot credentials.
+FEISHU_APP_ID=cli_changeme
+FEISHU_APP_SECRET=changeme-do-not-commit
+FEISHU_DOMAIN=feishu
+FEISHU_CONNECTION_MODE=websocket
+FEISHU_ALLOW_ALL_USERS=false
+FEISHU_GROUP_POLICY=allowlist
+FEISHU_ALLOWED_USERS=
+FEISHU_ALLOWED_CHATS=
+
+# Hermes runtime boundary.
+HERMES_HOME=/opt/autovmware-hermes-brain/hermes
+HERMES_PROFILE=autovmware-brain
+
+# Worker heartbeat/control API.
+BRAIN_API_HOST=0.0.0.0
+BRAIN_API_PORT=3104
+BRAIN_STATE_PATH=/opt/autovmware-hermes-brain/state/workers.json
+
+# Model/provider values are runtime-specific and should be injected on ECS.
+# OPENAI_API_KEY=changeme-do-not-commit
+# ANTHROPIC_API_KEY=changeme-do-not-commit
+# KIMI_API_KEY=changeme-do-not-commit

--- a/deploy/hermes-brain/start.sh
+++ b/deploy/hermes-brain/start.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p "${HERMES_HOME:-/opt/autovmware-hermes-brain/hermes}" \
+  /opt/autovmware-hermes-brain/state \
+  /opt/autovmware-hermes-brain/logs
+
+export HERMES_HOME="${HERMES_HOME:-/opt/autovmware-hermes-brain/hermes}"
+export HERMES_PROFILE="${HERMES_PROFILE:-autovmware-brain}"
+export BRAIN_API_HOST="${BRAIN_API_HOST:-0.0.0.0}"
+export BRAIN_API_PORT="${BRAIN_API_PORT:-3104}"
+export BRAIN_STATE_PATH="${BRAIN_STATE_PATH:-/opt/autovmware-hermes-brain/state/workers.json}"
+
+python /opt/autovmware-hermes-brain/brain_api.py \
+  >>/opt/autovmware-hermes-brain/logs/brain-api.log \
+  2>>/opt/autovmware-hermes-brain/logs/brain-api.err &
+api_pid=$!
+
+cleanup() {
+  kill "$api_pid" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Hermes Feishu websocket credentials come from env file. Never bake them into image.
+exec python -m hermes_cli.main gateway run --replace

--- a/docs/codex-prompts/deploy-autovmware-worker-to-target-machine.md
+++ b/docs/codex-prompts/deploy-autovmware-worker-to-target-machine.md
@@ -1,0 +1,138 @@
+# Codex Prompt: Deploy AutoVMware Worker to Target Machine
+
+把下面整段提示词交给 Codex，让 Codex 连接一台目标 Windows 运维机器完成 AutoVMware Worker 部署、注册、heartbeat 验收。Codex 必须只做注册和只读检查，不要执行真实 clone。
+
+---
+
+你是 Codex，正在连接一台 Windows 目标机器，用于把这台机器注册到 AutoVMware Hermes Brain。
+
+## 目标
+
+在目标机器上部署/验证 AutoVMware Worker，使它能向 Brain 上报 heartbeat。完成后输出可审计验收结果。不要执行真实 clone、start、power on、delete、snapshot、cleanup。
+
+## 已知 Brain 信息
+
+- Brain API Base URL: `<BRAIN_API_BASE_URL>`，示例：`http://8.138.7.116:3104`
+- Heartbeat endpoint: `POST <BRAIN_API_BASE_URL>/workers/heartbeat`
+- 本机 machine_id: `<MACHINE_ID>`
+- AutoVMware 默认目录：`C:\Users\<WindowsUser>\Documents\AutoVMware`
+
+如果 `<BRAIN_API_BASE_URL>` 或 `<MACHINE_ID>` 未提供，先向用户要这两个值，不要猜。
+
+## 安全边界
+
+- 不要输出 token、密码、RustDesk 凭据、Feishu secret、`.env` 内容。
+- 不要读取或打印 `.env`。
+- 不要执行真实 VMware clone/start/stop/delete/snapshot/cleanup/power on。
+- 如果看到验证码、账号安全验证、密码输入框或不确定 UI，停止并询问用户。
+- 只允许执行只读环境检查、AutoVMware 安装目录检查、token present/missing 检查、doctor dry-run。
+
+## 执行步骤
+
+1. 确认机器身份和基础环境：
+
+```powershell
+$env:COMPUTERNAME
+$env:USERNAME
+$autoRoot = Join-Path $env:USERPROFILE "Documents\AutoVMware"
+Test-Path $autoRoot
+python --version
+```
+
+2. 如果 AutoVMware 目录不存在：
+   - 查找用户给定的 Release zip 或解压目录。
+   - 如果没有交付包，报告 `blocked: missing AutoVMware release package`，不要从未知 URL 下载。
+   - 如果有交付包，运行：
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass -Force
+.\install.ps1 -SkipKimiInstall
+```
+
+3. 只读验证 token/skill 状态：
+
+```powershell
+cd $autoRoot
+python .\skills\autovmware-macos-vmx-clone\scripts\cli.py ops-status --format json
+```
+
+注意：输出中 token 只能是 `[redacted]` 或 missing/present 状态，不要输出真实值。
+
+4. 运行 doctor，只读，不 clone：
+
+```powershell
+cd $autoRoot
+python .\skills\autovmware-macos-vmx-clone\scripts\cli.py doctor --format json
+```
+
+5. 计算状态：
+
+- 如果 AutoVMware 不存在：`blocked`
+- 如果 token 缺失：`need_token`
+- 如果磁盘不足：`low_disk`
+- 如果 doctor 失败：`doctor_failed`
+- 如果基础检查通过：`ready`
+
+6. 向 Brain 注册 heartbeat。示例 PowerShell：
+
+```powershell
+$brain = "<BRAIN_API_BASE_URL>"
+$machineId = "<MACHINE_ID>"
+$autoRoot = Join-Path $env:USERPROFILE "Documents\AutoVMware"
+$drive = Get-PSDrive -Name F -ErrorAction SilentlyContinue
+$freeGb = if ($drive) { [Math]::Round($drive.Free / 1GB, 2) } else { 0 }
+
+$body = @{
+  machine_id = $machineId
+  hostname = $env:COMPUTERNAME
+  worker_version = "0.1.0"
+  windows_user = $env:USERNAME
+  autovmware_root = $autoRoot
+  vmware_status = "unknown"
+  python_status = "ok"
+  kimi_token_present = $false
+  free_space_gb = $freeGb
+  current_state = "blocked"
+  last_error = "replace with actual blocker or null"
+  evidence_path = (Join-Path $autoRoot "reports\worker-register.md")
+} | ConvertTo-Json -Depth 5
+
+Invoke-RestMethod -Method Post -Uri "$brain/workers/heartbeat" -ContentType "application/json" -Body $body
+```
+
+请根据实际检查结果替换 `kimi_token_present`、`current_state`、`last_error`。如果能从 `ops-status` 安全读取 token_present，则使用该布尔值，但不要输出 token。
+
+7. 写本机验收报告：
+
+路径：`C:\Users\<WindowsUser>\Documents\AutoVMware\reports\worker-register.md`
+
+报告包含：
+
+- machine_id
+- hostname
+- windows_user
+- AutoVMware path exists / missing
+- python version
+- ops-status summary，token 只写 present/missing/redacted
+- doctor summary
+- heartbeat POST response
+- final state
+- blockers / next action
+
+## 验收输出
+
+最后只输出以下摘要，不要输出任何 secret：
+
+```text
+AutoVMware Worker Registration Result
+machine_id: <...>
+hostname: <...>
+state: ready|blocked|need_token|low_disk|doctor_failed
+brain_heartbeat: accepted|failed
+report_path: <local path>
+blocked_reason: <if any>
+real_vm_action_executed: false
+secret_leak_check: pass
+```
+
+如果 heartbeat 失败，给出 HTTP 状态、错误类型和本机网络检查结果；不要继续执行 clone。

--- a/docs/control-plane/hermes-brain-worker-contract.md
+++ b/docs/control-plane/hermes-brain-worker-contract.md
@@ -1,0 +1,76 @@
+# AutoVMware Hermes Brain / Worker Contract
+
+本文定义飞书 Hermes Brain 与每台 AutoVMware Windows Worker 的第一版工程契约。目标是先把“机器是否可调度”打通，不执行真实 clone。
+
+## Control-plane endpoints
+
+第一版 Brain API 暴露在阿里云 ECS Podman 容器内，建议端口 `3104`：
+
+- `GET /health`：Brain API 存活检查。
+- `GET /workers`：查看当前 worker registry。
+- `POST /workers/heartbeat`：目标机器上报 heartbeat。
+
+Feishu websocket 由容器内 Hermes Gateway 负责；Worker API 由同容器 `brain_api.py` 负责。两者共享同一 Podman runtime 边界，但 secrets 不写入镜像。
+
+## POST /workers/heartbeat
+
+Worker 每 30-60 秒上报一次；目标机器部署阶段也可以手动上报一次作为注册验收。
+
+```json
+{
+  "machine_id": "PC12",
+  "hostname": "PC12-WIN",
+  "worker_version": "0.1.0",
+  "windows_user": "PC12",
+  "autovmware_root": "C:\\Users\\PC12\\Documents\\AutoVMware",
+  "vmware_status": "installed",
+  "python_status": "ok",
+  "kimi_token_present": true,
+  "kimi_token_value": "[redacted]",
+  "free_space_gb": 373.7,
+  "current_state": "ready",
+  "last_error": null,
+  "evidence_path": "C:\\Users\\PC12\\Documents\\AutoVMware\\reports\\worker-register.md"
+}
+```
+
+### Required fields
+
+- `machine_id`
+- `hostname`
+- `worker_version`
+- `free_space_gb`
+- `kimi_token_present`
+- `current_state`
+
+### Allowed states
+
+| State | Meaning | Next action |
+|---|---|---|
+| `ready` | Worker、Python、AutoVMware 基础检查通过，可以接受只读任务 | 允许 doctor/token-check/plan |
+| `blocked` | 有明确阻塞，不能继续推进 | 生成失败包，等待人工处理 |
+| `lost` | Brain 认为 heartbeat 超时 | 检查机器网络/worker service |
+| `need_token` | Worker 可达但 Kimi token 缺失 | 本机安全配置 token，不在飞书/GitHub 输出 |
+| `low_disk` | 目标盘不足 | 降低 clone_count 或释放磁盘 |
+| `doctor_failed` | AutoVMware doctor 失败 | 修复 doctor blocker 后再上报 |
+| `installed` | AutoVMware 已安装，但尚未 token/doctor OK | 进入 token-check |
+| `token_ok` | token present 且 redacted | 进入 doctor |
+| `doctor_ok` | doctor 通过 | 允许生成 plan |
+| `plan_ready` | 计划已生成但未审批 | 等飞书/负责人审批 |
+
+## Safety rules
+
+- 第一阶段只做注册、heartbeat、doctor/token-check/plan；不执行真实 clone。
+- 不执行真实 clone、start、power on、delete、snapshot、cleanup，除非后续 Story 明确授权并走飞书审批。
+- Worker 不得把 Kimi token、Feishu secret、RustDesk 密码、Windows 密码、`.env` 内容写入 heartbeat、日志、截图或 GitHub Issue。
+- Brain 保存敏感字段时必须 redacted。字段名包含 `token`、`password`、`secret`、`credential` 时默认脱敏；`kimi_token_present` 是布尔状态例外。
+- `@所有人`、群公告和含糊批量指令不得触发真实机器动作。
+
+## Acceptance checklist
+
+1. ECS 上 Podman container `autovmware-hermes-brain` 运行。
+2. `curl http://127.0.0.1:3104/health` 返回 `ok=true`。
+3. 目标 Windows 机器用 Codex 执行部署提示词后，能 POST heartbeat 到 Brain。
+4. `GET /workers` 能看到该 `machine_id`，且 token 只显示 present/redacted 状态。
+5. 飞书询问机器状态时，Brain 能返回 ready / blocked / lost / need_token / low_disk / doctor_failed。
+6. 验收报告包含 container status、worker heartbeat response、worker evidence path；不包含任何真实 secret。

--- a/docs/deployment/aliyun-podman-hermes-brain.md
+++ b/docs/deployment/aliyun-podman-hermes-brain.md
@@ -1,0 +1,80 @@
+# Aliyun Podman Hermes Brain Deployment
+
+本文是 AutoVMware 飞书中枢大脑的工程化部署说明。目标运行时是阿里云 ECS 上的 Podman 容器，容器内运行 Hermes Gateway 连接飞书 websocket，同时运行轻量 Brain API 接收 AutoVMware Worker heartbeat。
+
+## Resource assumptions checked on 2026-05-08
+
+- OS: Ubuntu 24.04 LTS
+- CPU: 4 cores
+- Memory: 14Gi total，约 12Gi available
+- Disk: root 49G，约 31G free
+- Feishu OpenAPI egress: OK
+- Podman: apt 可安装，当前非预装
+- Suggested Brain API port: `3104`
+
+## Runtime boundary
+
+Accepted runtime must be the Podman container named `autovmware-hermes-brain`.
+
+Do not use an existing host Hermes process as acceptance evidence. Host Hermes may be old, dirty, or manually started. Acceptance must show:
+
+- `podman ps` contains `autovmware-hermes-brain`.
+- `systemctl status autovmware-hermes-brain.service` is active.
+- `curl http://127.0.0.1:3104/health` returns `ok=true`.
+- A worker heartbeat can be posted and then read from `GET /workers`.
+- Feishu bot sends/receives through the container runtime.
+- No real secrets appear in logs or reports.
+
+## Files
+
+- `deploy/hermes-brain/Containerfile` — Hermes Brain image.
+- `deploy/hermes-brain/env.example` — environment template; copy to ECS and fill secrets there.
+- `deploy/hermes-brain/start.sh` — starts Brain API and Hermes Gateway.
+- `deploy/hermes-brain/brain_api.py` — first-version heartbeat registry API.
+- `scripts/deploy/aliyun-podman-hermes-brain.sh` — ECS install/build/deploy/status helper.
+- `docs/control-plane/hermes-brain-worker-contract.md` — worker heartbeat contract.
+- `docs/codex-prompts/deploy-autovmware-worker-to-target-machine.md` — prompt to hand to Codex for target-machine registration.
+
+## ECS deployment steps
+
+Run on ECS as root from a fresh checkout of this repo:
+
+```bash
+bash scripts/deploy/aliyun-podman-hermes-brain.sh install-podman
+bash scripts/deploy/aliyun-podman-hermes-brain.sh build
+bash scripts/deploy/aliyun-podman-hermes-brain.sh deploy
+```
+
+On first deploy, the script creates:
+
+```text
+/opt/autovmware-hermes-brain/brain.env
+```
+
+Fill real Feishu/model credentials in that file on ECS only. Do not commit it and do not print it.
+
+## Status check
+
+```bash
+bash scripts/deploy/aliyun-podman-hermes-brain.sh status
+curl -fsS http://127.0.0.1:3104/health
+curl -fsS http://127.0.0.1:3104/workers
+```
+
+## Worker heartbeat smoke
+
+```bash
+curl -fsS -X POST http://127.0.0.1:3104/workers/heartbeat \
+  -H 'Content-Type: application/json' \
+  -d '{"machine_id":"smoke","hostname":"smoke","worker_version":"0.1.0","free_space_gb":100,"kimi_token_present":false,"current_state":"need_token","last_error":"smoke"}'
+```
+
+## Deployment handoff to Codex
+
+When deploying to real AutoVMware target machines, do not let this repo agent directly operate those machines. Use:
+
+```text
+docs/codex-prompts/deploy-autovmware-worker-to-target-machine.md
+```
+
+Give Codex the `BRAIN_API_BASE_URL` and target `machine_id`. Codex must connect to the target machine, deploy or verify AutoVMware Worker, POST heartbeat, and return evidence. It must stop before any real clone.

--- a/docs/ideation/2026-05-08-autovmware-feishu-brain-ideation.md
+++ b/docs/ideation/2026-05-08-autovmware-feishu-brain-ideation.md
@@ -1,0 +1,156 @@
+---
+date: 2026-05-08
+topic: autovmware-feishu-brain
+focus: Feishu-operated central brain controlling every deployed AutoVMware computer
+---
+
+# Ideation: AutoVMware 飞书中枢大脑
+
+## Codebase Context
+
+本轮针对 `/Users/wangrenzhu/work/AutoVMware-Kimi-Ops-Runbook` 做了浅层扫描。仓库当前更像“AutoVMware + Kimi + PowerShell/Python 的 Windows 本地运维交付包”，而不是 fleet control plane。
+
+项目形态：Python >=3.10 CLI/scripts、PowerShell install/bootstrap/acceptance/release scripts、pytest、YAML skill contract、JSON config。主要目录包括 `skills/autovmware-macos-vmx-clone`、`scripts/{acceptance,bootstrap,release}`、`docs/{ops,reports}`、`config`、`tests`。
+
+现有强约束：`doctor/discover/generate-approval/validate/plan` 是只读；真实 clone 需要明确人工确认；clone count capped 1-100；磁盘预算需要 `clone_count * disk_gb + 100GB reserve`；默认 `power_on=false`；token 必须 redacted。
+
+关键缺口：没有常驻 worker/daemon、machine registry、remote command bus、Feishu bot/webhook、queue、authz model、audit backend。默认配置仍偏 DEM-009/F:/PC12 场景。
+
+历史学习：现有部署计划已经定义 Feishu 机器清单和状态门：`inventory_pending -> remote_ok -> installed -> token_ok -> doctor_ok -> plan_ready -> clone_running -> clone_done/blocked`。首批 Kimi 5 台 clone 只有 3 台完整、1 台 incomplete、1 台未完整形成，说明不能把“已安装 AutoVMware”当成“真实 clone 稳定”。RustDesk/GUI 远控被证明易受 PowerShell 特殊字符和 clipboard 影响，适合作为 bootstrap/rescue，不适合作为主命令平面。
+
+## Ranked Ideas
+
+### 1. Feishu 中枢大脑：消息先落 Task/Run，再路由到机器 worker
+
+**Description:** 飞书不直接成为远程 shell，而是把用户意图编译成结构化 task/run：发起人、目标机器/机器组、动作、参数、风险等级、审批策略、过期时间。中央 brain 负责调度、状态门禁、审计和重试；每台 Windows AutoVMware worker 负责执行受控动作并回写结果。这样用户在飞书上操控的是一个生产控制面，而不是群聊机器人转发命令。
+
+**Warrant:** `direct:` 仓库当前是本地 Kimi/PowerShell/Python safe local commands，明确缺少 daemon/registry/bus/bot/queue/authz/audit；用户目标是“能在飞书上操控一个大脑，控制每个部署了 AutoVMware 的电脑”。
+
+**Rationale:** 这是从“单机 runbook”跃迁到“fleet brain”的核心抽象。只要 Task/Run 成立，审批、队列、证据、状态、并发、重试、权限都能围绕同一对象复用。
+
+**Downsides:** 需要新增服务端控制面、数据模型、worker 协议和 Feishu bot；不是小修。
+
+**Confidence:** 92%
+
+**Complexity:** High
+
+**Status:** Unexplored
+
+### 2. 每台机器 worker heartbeat + 可调度性状态
+
+**Description:** 每台部署 AutoVMware 的 Windows 机器运行轻量 worker，周期上报 `machine_id`、runner version、VMware/Python/Kimi 状态、token present/missing redacted、free space、当前任务、最近错误、last_heartbeat_at。中央 brain 只调度 heartbeat 新鲜、状态门满足、风险策略通过的机器。Feishu 里展示“哪些机器 ready、blocked、lost、需要人工救援”。
+
+**Warrant:** `direct:` 现有计划已有 per-machine 字段和状态门；相邻经验明确建议 central scheduler + per-Windows worker；当前 repo 没有 agent daemon/registry/remote bus。
+
+**Rationale:** fleet 控制的第一问题不是“能不能执行 clone”，而是“哪台机器现在可信、可用、可调度”。heartbeat 让电脑从黑盒远程桌面变成可观测 runtime。
+
+**Downsides:** 需要处理 worker 安装、升级、掉线、版本兼容、安全鉴权。
+
+**Confidence:** 90%
+
+**Complexity:** Medium-High
+
+**Status:** Unexplored
+
+### 3. 把状态门升级为自动状态机，而不是人工 checklist
+
+**Description:** 将 `inventory_pending -> remote_ok -> installed -> token_ok -> doctor_ok -> plan_ready -> clone_running -> clone_done/blocked` 变成严格状态机。每个状态定义进入条件、退出条件、超时、失败重试、需要人工确认的点、禁止跳转规则。Feishu 只展示“现在可做什么”和“为什么不能继续”，而不是让人读 runbook 判断下一步。
+
+**Warrant:** `direct:` 部署计划已经定义完整状态门并明确不要跳过；首批 5 台只有 3 台完整，说明人工推进和稳定性门禁不足。
+
+**Rationale:** 这能把安全 SOP 从文档转成系统行为，避免忙时跳步，也方便后续 wave rollout、失败暂停、自动恢复。
+
+**Downsides:** 状态机设计需要覆盖异常路径；如果做得过重，初期会拖慢试验速度。
+
+**Confidence:** 88%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 4. Feishu 风险差异审批：确认授权对象，而不是确认聊天话术
+
+**Description:** 真实 clone 前不再靠自然语言确认，而是生成带作用域的授权对象：`machine_id`、`clone_count`、`source_vmx`、`target_root`、`power_on`、磁盘 reserve、过期时间、审批人、审批来源。普通安全路径低摩擦确认；异常差异如 `power_on=true`、reserve 接近下限、目标路径非预期、clone count 高，审批卡突出风险差异。
+
+**Warrant:** `direct:` 现有 skill/plan 要求真实 clone 前完整字段确认；当前安全规则包含 count cap、100GB reserve、默认 power_on=false、token redaction。
+
+**Rationale:** 聊天确认在单机阶段可用，但 fleet 下容易出现确认对象不清、复制到错误机器、确认疲劳。授权对象能让 worker 和 brain 都能机器验证“这次是否被允许”。
+
+**Downsides:** 需要接飞书审批/卡片能力和审批数据持久化；也需要定义哪些操作必须审批。
+
+**Confidence:** 86%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 5. 批次/Wave 调度器：自动 canary、暂停扩张、收口失败机器
+
+**Description:** 中央 brain 按机器组和 batch 管理 rollout：每组先选一台 canary，完成 `clone_done` 且报告验证通过后，才允许扩展到 10/50/100。出现 incomplete clone、worker lost、磁盘不足或 forbidden-action 风险时自动暂停扩大，只允许诊断、清理、小批重试。Feishu 汇报不只显示“3/5 完成”，还自动给剩余机器的失败包和下一步建议。
+
+**Warrant:** `direct:` 历史学习要求每组先验证一台再扩展；首批 5 台只有 3 台完整，1 incomplete，1 not fully formed；已有状态门和 per-machine 字段可作为调度输入。
+
+**Rationale:** 这把首批失败暴露出的不稳定性转化为调度策略，避免 central brain 只是更快地把错误放大到所有电脑。
+
+**Downsides:** 需要定义稳定性评分、暂停条件、恢复条件；短期会降低“看起来的速度”。
+
+**Confidence:** 84%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 6. Route evidence pack：每次 Feishu 指令自动生成验收证据包
+
+**Description:** 每个 run 自动生成证据包：Feishu message id、task_id、run_id、选中的 runtime、worker PID/service status、端口/health、tools/capabilities、dry-run plan、tool call request/response 摘要、stdout/stderr/exit code、artifact/report 路径、audit log offset。Feishu 回复“完成”时同时给证据摘要和 report 链接/路径。
+
+**Warrant:** `direct:` 用户验收严格要求真实黑盒留痕；gateway acceptance 需要 real Feishu send/receive、launchd/worker PID、route evidence；AutoVMware 报告已要求源 VMX、clone count、空间、截图、禁止动作、每机验证。
+
+**Rationale:** 控制面能否被信任，取决于每次动作是否可追溯。证据包会把一次性操作沉淀为排障、审计、验收和知识复利资产。
+
+**Downsides:** 日志量和隐私/redaction 复杂度上升；需要避免把证据系统做成泄密通道。
+
+**Confidence:** 82%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 7. Command manifest：把本地安全命令升级为远程可调度动作模板
+
+**Description:** 为每个 AutoVMware 动作声明 manifest：`name`、`risk_level`、`required_capabilities`、`inputs_schema`、`dry_run_supported`、`approval_required`、`evidence_required`、`rollback/delete_strategy`。Feishu brain 只能调度 manifest 中声明过的动作；worker 只执行受控模板并返回结构化结果。
+
+**Warrant:** `direct:` 当前仓库已有安全本地命令和 PowerShell/Python skill，但没有 fleet/control plane primitives；现有 schema/defaults 仍偏 DEM-009，容易把测试便利值当成控制面事实。
+
+**Rationale:** manifest 是复利层：每新增一个动作，审批、审计、输入校验、证据包、测试都能自动继承，而不是为每个脚本重新写胶水。
+
+**Downsides:** 初期需要梳理现有命令契约；过早抽象可能导致动作开发变慢。
+
+**Confidence:** 78%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | 单纯做一个 Feishu bot 转发 CLI 命令 | 被更强的 Task/Run 控制面覆盖；直接转发会把聊天机器人做成脆弱远程 shell。 |
+| 2 | 每台机器一张 Feishu 可执行体检卡 | 有价值但更像状态机/heartbeat 的 UI 表达，作为 survivor #2/#3 的 brainstorm variant 更合适。 |
+| 3 | blocked 自动生成修复工单 | 有价值但被 route evidence pack + wave 收口失败包覆盖。 |
+| 4 | 自动按机器准备度编队 | 被 wave 调度器覆盖；单独作为 idea 颗粒度偏窄。 |
+| 5 | 操作者 timeline | 被 route evidence pack 覆盖；timeline 是证据包的展示层。 |
+| 6 | 群聊降噪模式 | 必要但偏治理策略，不足以单独作为本轮核心产品改进；可纳入 Feishu gateway policy。 |
+| 7 | RustDesk 降级为救援通道 | 重要判断，但更像架构原则，已并入 central brain + worker heartbeat 的 rationale。 |
+| 8 | 敏感字段 redaction 管线 / credential lease | 必要安全基础，但当前 ideation 聚焦自动化控制面；可作为审批/证据包的硬约束。 |
+| 9 | DEM-009 模板化为 scenario template | 方向正确但偏数据建模子问题；可并入 command manifest / inventory 设计。 |
+| 10 | VMX/template registry | 有价值但更像后续 domain capability，优先级低于通用控制面、heartbeat、状态机。 |
+| 11 | Feishu runbook memory | 符合复利，但当前更应先建立 run/evidence/audit 数据源；否则 memory 会缺乏稳定输入。 |
+| 12 | WeChat break-glass 通道 | 符合既有治理，但不是 AutoVMware repo 自动化不足的核心解。 |
+
+## Suggested Handoff
+
+建议先进入 `gh:brainstorm` 深挖 Idea #1：`Feishu 中枢大脑：消息先落 Task/Run，再路由到机器 worker`。
+
+原因：它会自然拆出最小 MVP 边界：Feishu intake、Task/Run schema、machine heartbeat、worker command runner、approval gate、evidence pack。后续 #2-#7 都能作为该 brainstorm 的组成模块，而不是分散成多个独立项目。

--- a/scripts/deploy/aliyun-podman-hermes-brain.sh
+++ b/scripts/deploy/aliyun-podman-hermes-brain.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="${APP_NAME:-autovmware-hermes-brain}"
+APP_DIR="${APP_DIR:-/opt/autovmware-hermes-brain}"
+IMAGE_TAG="${IMAGE_TAG:-localhost/${APP_NAME}:latest}"
+BRAIN_PORT="${BRAIN_PORT:-3104}"
+ENV_FILE="${ENV_FILE:-${APP_DIR}/brain.env}"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run as root on Aliyun ECS." >&2
+  exit 1
+fi
+
+install_podman() {
+  if command -v podman >/dev/null 2>&1; then
+    podman --version
+    return 0
+  fi
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get install -y podman uidmap slirp4netns fuse-overlayfs
+  podman --version
+}
+
+prepare_dirs() {
+  install -d -m 0750 "${APP_DIR}" "${APP_DIR}/state" "${APP_DIR}/logs" "${APP_DIR}/hermes"
+  if [[ ! -f "${ENV_FILE}" ]]; then
+    install -m 0600 "${REPO_DIR}/deploy/hermes-brain/env.example" "${ENV_FILE}"
+    echo "Created ${ENV_FILE}; fill real Feishu/model credentials before starting." >&2
+    exit 2
+  fi
+  chmod 0600 "${ENV_FILE}"
+}
+
+build_image() {
+  podman build -t "${IMAGE_TAG}" -f "${REPO_DIR}/deploy/hermes-brain/Containerfile" "${REPO_DIR}"
+}
+
+write_unit() {
+  cat >"/etc/systemd/system/${APP_NAME}.service" <<EOF
+[Unit]
+Description=AutoVMware Hermes Brain (Podman)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Restart=always
+RestartSec=5
+EnvironmentFile=${ENV_FILE}
+ExecStartPre=-/usr/bin/podman rm -f ${APP_NAME}
+ExecStart=/usr/bin/podman run --name ${APP_NAME} --replace \\
+  --env-file ${ENV_FILE} \\
+  -p ${BRAIN_PORT}:${BRAIN_PORT} \\
+  -v ${APP_DIR}/hermes:/opt/autovmware-hermes-brain/hermes:Z \\
+  -v ${APP_DIR}/state:/opt/autovmware-hermes-brain/state:Z \\
+  -v ${APP_DIR}/logs:/opt/autovmware-hermes-brain/logs:Z \\
+  ${IMAGE_TAG}
+ExecStop=/usr/bin/podman stop -t 30 ${APP_NAME}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  systemctl daemon-reload
+}
+
+case "${1:-deploy}" in
+  install-podman)
+    install_podman
+    ;;
+  build)
+    install_podman
+    build_image
+    ;;
+  deploy)
+    install_podman
+    prepare_dirs
+    build_image
+    write_unit
+    systemctl enable --now "${APP_NAME}.service"
+    systemctl --no-pager --full status "${APP_NAME}.service" | sed -n '1,40p'
+    curl -fsS "http://127.0.0.1:${BRAIN_PORT}/health"
+    echo
+    ;;
+  status)
+    systemctl --no-pager --full status "${APP_NAME}.service" | sed -n '1,80p' || true
+    podman ps --filter "name=${APP_NAME}" --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}' || true
+    curl -fsS "http://127.0.0.1:${BRAIN_PORT}/health" || true
+    echo
+    ;;
+  *)
+    echo "Usage: $0 [install-podman|build|deploy|status]" >&2
+    exit 64
+    ;;
+esac

--- a/tests/test_hermes_brain_deployment.py
+++ b/tests/test_hermes_brain_deployment.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_podman_hermes_brain_deployment_artifacts_are_declared() -> None:
+    containerfile = read("deploy/hermes-brain/Containerfile")
+    env_example = read("deploy/hermes-brain/env.example")
+    deploy_script = read("scripts/deploy/aliyun-podman-hermes-brain.sh")
+
+    assert "HERMES_HOME" in containerfile
+    assert "hermes_cli.main" in containerfile
+    assert "gateway run" in containerfile
+    assert "FEISHU_APP_ID=" in env_example
+    assert "FEISHU_APP_SECRET=" in env_example
+    assert "changeme" in env_example.lower()
+    assert "podman" in deploy_script
+    assert "autovmware-hermes-brain" in deploy_script
+    assert "--replace" in deploy_script
+
+
+def test_brain_contract_documents_worker_heartbeat_and_states() -> None:
+    contract = read("docs/control-plane/hermes-brain-worker-contract.md")
+
+    for field in [
+        "machine_id",
+        "hostname",
+        "worker_version",
+        "free_space_gb",
+        "kimi_token_present",
+        "current_state",
+        "last_error",
+    ]:
+        assert field in contract
+
+    for state in ["ready", "blocked", "lost", "need_token", "low_disk", "doctor_failed"]:
+        assert state in contract
+
+    assert "POST /workers/heartbeat" in contract
+    assert "不执行真实 clone" in contract
+
+
+def test_codex_target_machine_prompt_is_self_contained_and_safe() -> None:
+    prompt = read("docs/codex-prompts/deploy-autovmware-worker-to-target-machine.md")
+
+    assert "Codex" in prompt
+    assert "AutoVMware" in prompt
+    assert "Brain" in prompt
+    assert "heartbeat" in prompt.lower()
+    assert "不要执行真实 clone" in prompt
+    assert "不要输出 token" in prompt
+    assert "验收输出" in prompt
+    assert re.search(r"machine_id", prompt)
+
+
+def test_linux_ci_validates_podman_brain_artifacts() -> None:
+    workflow = read(".github/workflows/linux-brain-ci.yml")
+
+    assert "runs-on: ubuntu-latest" in workflow
+    assert "python -m pytest -q" in workflow
+    assert "podman" in workflow.lower()
+    assert "deploy/hermes-brain/Containerfile" in workflow
+    assert "tests/test_hermes_brain_deployment.py" in workflow


### PR DESCRIPTION
## Summary

Adds the first engineering slice for the AutoVMware Feishu Hermes Brain Epic:

- Podman-scoped Hermes Brain deployment scaffold for Aliyun ECS.
- Lightweight Brain API for `/health`, `/workers`, and `/workers/heartbeat`.
- Worker heartbeat/control-plane contract and deployment runbook.
- Paste-ready Codex prompt for target-machine AutoVMware worker deployment/registration.
- Linux CI path validating Python tests, deployment artifacts, shell syntax, and Brain API smoke.

## Scope

This PR completes the engineering artifacts for Stories 1-3. It intentionally does not deploy to real Windows target machines and does not execute real VMware clone/start/delete/snapshot operations.

## Validation

Local:

```text
python3 -m pytest -q
15 passed in 0.02s

bash -n scripts/deploy/aliyun-podman-hermes-brain.sh
bash -n deploy/hermes-brain/start.sh

Brain API smoke:
GET /health -> ok=true
POST /workers/heartbeat -> accepted local-ci need_token
GET /workers -> local-ci stored
```

## Safety

- No real Feishu secrets, Kimi tokens, RustDesk credentials, or `.env` contents committed.
- `env.example` uses placeholders only.
- Worker prompt explicitly forbids real clone/start/power on/delete/snapshot/cleanup.
- Accepted runtime boundary is Podman container `autovmware-hermes-brain`, not existing host Hermes.

Refs #12
Closes #13
Closes #14
Closes #15
