### PR TITLE
fix: harden Hermes Brain ECS image build

### DIFF
--- a/deploy/hermes-brain/Containerfile
+++ b/deploy/hermes-brain/Containerfile
@@ -12,16 +12,20 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     HERMES_PROFILE=autovmware-brain \
     BRAIN_API_HOST=0.0.0.0 \
     BRAIN_API_PORT=3104 \
+    PIP_INDEX_URL=https://mirrors.aliyun.com/pypi/simple \
+    PIP_TRUSTED_HOST=mirrors.aliyun.com \
     PATH=/opt/hermes-venv/bin:$PATH
 
-RUN apt-get update \
+RUN sed -i 's|http://deb.debian.org/debian|http://mirrors.aliyun.com/debian|g; s|http://deb.debian.org/debian-security|http://mirrors.aliyun.com/debian-security|g' /etc/apt/sources.list.d/debian.sources \
+    && apt-get update \
     && apt-get install -y --no-install-recommends git curl ca-certificates tini \
     && rm -rf /var/lib/apt/lists/*
 
 RUN git clone --depth 1 --branch "${HERMES_REF}" "${HERMES_REPO}" /opt/hermes-agent \
     && python -m venv /opt/hermes-venv \
     && /opt/hermes-venv/bin/python -m pip install --upgrade pip setuptools wheel \
-    && /opt/hermes-venv/bin/python -m pip install -e /opt/hermes-agent
+    && /opt/hermes-venv/bin/python -m pip install -e /opt/hermes-agent \
+    && /opt/hermes-venv/bin/python -m pip install lark-oapi
 
 WORKDIR /opt/autovmware-hermes-brain
 COPY deploy/hermes-brain/brain_api.py /opt/autovmware-hermes-brain/brain_api.py


### PR DESCRIPTION
## Summary

Hardens the Hermes Brain image for the real Aliyun ECS deployment path:

- Uses Aliyun Debian mirrors inside the container build to avoid Docker Hub/Debian mirror timeout on ECS.
- Sets Aliyun PyPI mirror envs for build-time package resolution.
- Installs `lark-oapi`, which is required for the Feishu websocket adapter in the container runtime.

## Validation

Local:

```text
python3 -m pytest tests/test_hermes_brain_deployment.py -q
4 passed
```

Real ECS deployment evidence from Story #16:

```text
podman build -> success
systemctl is-active autovmware-hermes-brain.service -> active
podman ps -> autovmware-hermes-brain Up, 0.0.0.0:3104->3104/tcp
curl http://127.0.0.1:3104/health -> ok=true
Feishu websocket log -> connected to msg-frontier.feishu.cn
```

No secrets committed.

Refs #16
