### PR TITLE
fix: store OpsBrain Podman data under /data

### DIFF
--- a/docs/deployment/aliyun-podman-hermes-brain.md
+++ b/docs/deployment/aliyun-podman-hermes-brain.md
@@ -7,7 +7,7 @@
 - OS: Ubuntu 24.04 LTS
 - CPU: 4 cores
 - Memory: 14Gi total，约 12Gi available
-- Disk: root 49G，约 31G free
+- Disk: root 49G，约 31G free；`/data` 独立 196G 数据盘
 - Feishu OpenAPI egress: OK
 - Podman: apt 可安装，当前非预装
 - Suggested Brain API port: `3104`
@@ -20,6 +20,7 @@ Do not use an existing host Hermes process as acceptance evidence. Host Hermes m
 
 - `podman ps` contains `autovmware-hermes-brain`.
 - `systemctl status autovmware-hermes-brain.service` is active.
+- Podman persistent bind mounts use `/data/autovmware-hermes-brain/{hermes,state,logs}` on the ECS data disk.
 - `curl http://127.0.0.1:3104/health` returns `ok=true`.
 - A worker heartbeat can be posted and then read from `GET /workers`.
 - Feishu bot sends/receives through the container runtime.
@@ -52,6 +53,16 @@ On first deploy, the script creates:
 ```
 
 Fill real Feishu/model credentials in that file on ECS only. Do not commit it and do not print it.
+
+Persistent Podman bind-mount data is stored on the ECS data disk:
+
+```text
+/data/autovmware-hermes-brain/hermes
+/data/autovmware-hermes-brain/state
+/data/autovmware-hermes-brain/logs
+```
+
+Do not move these data volumes back under `/opt`; `/opt` is for config/env and service metadata only.
 
 ## Status check
 

--- a/scripts/deploy/aliyun-podman-hermes-brain.sh
+++ b/scripts/deploy/aliyun-podman-hermes-brain.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 APP_NAME="${APP_NAME:-autovmware-hermes-brain}"
 APP_DIR="${APP_DIR:-/opt/autovmware-hermes-brain}"
+# Persistent Podman bind-mount data must live on the ECS data disk.
+DATA_DIR="${DATA_DIR:-/data/autovmware-hermes-brain}"
 IMAGE_TAG="${IMAGE_TAG:-localhost/${APP_NAME}:latest}"
 BRAIN_PORT="${BRAIN_PORT:-3104}"
 ENV_FILE="${ENV_FILE:-${APP_DIR}/brain.env}"
@@ -24,7 +26,7 @@ install_podman() {
 }
 
 prepare_dirs() {
-  install -d -m 0750 "${APP_DIR}" "${APP_DIR}/state" "${APP_DIR}/logs" "${APP_DIR}/hermes"
+  install -d -m 0750 "${APP_DIR}" "${DATA_DIR}" "${DATA_DIR}/state" "${DATA_DIR}/logs" "${DATA_DIR}/hermes"
   if [[ ! -f "${ENV_FILE}" ]]; then
     install -m 0600 "${REPO_DIR}/deploy/hermes-brain/env.example" "${ENV_FILE}"
     echo "Created ${ENV_FILE}; fill real Feishu/model credentials before starting." >&2
@@ -52,9 +54,9 @@ ExecStartPre=-/usr/bin/podman rm -f ${APP_NAME}
 ExecStart=/usr/bin/podman run --name ${APP_NAME} --replace \\
   --env-file ${ENV_FILE} \\
   -p ${BRAIN_PORT}:${BRAIN_PORT} \\
-  -v ${APP_DIR}/hermes:/opt/autovmware-hermes-brain/hermes:Z \\
-  -v ${APP_DIR}/state:/opt/autovmware-hermes-brain/state:Z \\
-  -v ${APP_DIR}/logs:/opt/autovmware-hermes-brain/logs:Z \\
+  -v ${DATA_DIR}/hermes:/opt/autovmware-hermes-brain/hermes:Z \\
+  -v ${DATA_DIR}/state:/opt/autovmware-hermes-brain/state:Z \\
+  -v ${DATA_DIR}/logs:/opt/autovmware-hermes-brain/logs:Z \\
   ${IMAGE_TAG}
 ExecStop=/usr/bin/podman stop -t 30 ${APP_NAME}
 


### PR DESCRIPTION
## Summary
- Move OpsBrain Podman persistent bind mounts to /data/autovmware-hermes-brain/{hermes,state,logs}
- Keep /opt/autovmware-hermes-brain for env/config/service metadata
- Update deployment docs with /data data-disk requirement

## Runtime evidence
- ECS /data is /dev/vdb, 196G, 185G available
- Active service mounts now use /data/autovmware-hermes-brain/{hermes,state,logs}
- autovmware-hermes-brain.service active after restart
- /health returns ok=true; /workers still returns ecs-smoke with secrets redacted

## Validation
- bash -n scripts/deploy/aliyun-podman-hermes-brain.sh

Refs #19